### PR TITLE
[WIP] Feature/rerendering events based on children

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ React bindings for [imagesLoaded](http://imagesloaded.desandro.com) event system
 | onProgress | Function         |
 | onFail     | Function         |
 | done       | Function         |
+| onUpdate   | Function         |
 | background | String / Boolean |
 
 ## Example usage
@@ -34,6 +35,8 @@ class App extends Component {
 
   handleDone = instance => {};
 
+  handleOnUpdate = () => {};
+
   render() {
     return (
       <ImagesLoaded
@@ -43,6 +46,7 @@ class App extends Component {
         onProgress={this.handleOnProgress}
         onFail={this.handleOnFail}
         done={this.handleDone}
+        onUpdate={this.handleOnUpdate}
         background=".image" // true or child selector
       >
         {/* Your images */}

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ImagesLoaded /> should render and work. 1`] = `
+<div
+  className="images-loaded-container"
+>
+  <img
+    src="img1.jpg"
+  />
+</div>
+`;

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -1,12 +1,53 @@
 import React from 'react';
-import { render } from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import ImagesLoaded from '../src/index';
+import renderer from 'react-test-renderer';
 
-describe('ImagesLoaded Component', () => {
-  it('should render without crashing', () => {
-    const mountNode = document.createElement('div');
-    render(<ImagesLoaded />, mountNode);
+describe('<ImagesLoaded />', () => {
+  it('should render and work.', async () => {
+    const done = jest.fn();
+    const onAlways = jest.fn();
+    const onFail = jest.fn();
+    const onProgress = jest.fn();
+    const onUpdate = jest.fn();
+
+    const component = renderer.create(
+      <ImagesLoaded
+        done={done}
+        onAlways={onAlways}
+        onFail={onFail}
+        onProgress={onProgress}
+        onUpdate={onUpdate}
+      >
+        {['img1.jpg'].map((item, index) => <img key={index} src={item} />)}
+      </ImagesLoaded>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+
+    const instance = component.getInstance();
+    const cWU = jest.spyOn(instance, 'componentWillUnmount');
+    const cDU = jest.spyOn(instance, 'componentDidUpdate');
+
+    component.update(
+      <ImagesLoaded
+        done={done}
+        onAlways={onAlways}
+        onFail={onFail}
+        onProgress={onProgress}
+        onUpdate={onUpdate}
+      >
+        {['img1.jpg', 'img2.jpg'].map((item, index) => (
+          <img key={index} src={item} />
+        ))}
+      </ImagesLoaded>
+    );
+
+    expect(cDU).toHaveBeenCalled();
+
+    component.unmount();
+
+    expect(cWU).toHaveBeenCalled();
   });
 
   it('should render children', () => {
@@ -64,29 +105,5 @@ describe('ImagesLoaded Component', () => {
         'section'
       ).length
     ).toBeFalsy();
-  });
-
-  it('should render with the correct className', () => {
-    const defaultComponent = ReactTestUtils.renderIntoDocument(
-      <ImagesLoaded />
-    );
-
-    const customComponentClass = ReactTestUtils.renderIntoDocument(
-      <ImagesLoaded className={'my-custom-class'} />
-    );
-
-    expect(
-      ReactTestUtils.scryRenderedDOMComponentsWithClass(
-        defaultComponent,
-        'images-loaded-container'
-      ).length
-    ).toBeTruthy();
-
-    expect(
-      ReactTestUtils.scryRenderedDOMComponentsWithClass(
-        customComponentClass,
-        'my-custom-class'
-      ).length
-    ).toBeTruthy();
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -28,12 +28,14 @@ export default class ImagesLoaded extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { onUpdate } = this.props;
     if (prevProps.children !== this.props.children) {
       // Do a re-initialization of the imagesLoaded instance.
       // This may be useful if components that
       // are using this needs to update
       // images in children in result of a state change.
       this.initImagesLoaded();
+      onUpdate();
     }
   }
 
@@ -71,5 +73,6 @@ const propTypes = {
   done: PropTypes.func,
   onFail: PropTypes.func,
   onProgress: PropTypes.func,
+  onUpdate: PropTypes.func,
   background: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,18 +4,37 @@ import imagesLoaded from 'imagesloaded';
 import omit from 'lodash.omit';
 
 export default class ImagesLoaded extends Component {
-  componentDidMount() {
-    const { onAlways, done, onFail, onProgress, background } = this.props;
+  initImagesLoaded = () => {
+    const { background } = this.props;
     const { elemContainer } = this.refs;
 
     /* Initializing imagesLoaded */
     this.imagesLoaded = imagesLoaded(elemContainer, { background });
+    this.setEvents();
+  };
+
+  setEvents = () => {
+    const { onAlways, done, onFail, onProgress, background } = this.props;
 
     // add events
     this.imagesLoaded.on('always', onAlways);
     this.imagesLoaded.on('done', done);
     this.imagesLoaded.on('fail', onFail);
     this.imagesLoaded.on('progress', onProgress);
+  };
+
+  componentDidMount() {
+    this.initImagesLoaded();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps !== this.props) {
+      // Do a re-initialization of imagesLoaded instance
+      // to fire events again. This may be useful if
+      // components that are using this, and needs to update
+      // images in result of e.g a state change.
+      this.initImagesLoaded();
+    }
   }
 
   componentWillUnmount() {

--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,6 @@ import imagesLoaded from 'imagesloaded';
 import omit from 'lodash.omit';
 
 export default class ImagesLoaded extends Component {
-  initImagesLoaded = () => {
-    const { background } = this.props;
-    const { elemContainer } = this.refs;
-
-    /* Initializing imagesLoaded */
-    this.imagesLoaded = imagesLoaded(elemContainer, { background });
-    this.setEvents();
-  };
-
   setEvents = () => {
     const { onAlways, done, onFail, onProgress, background } = this.props;
 
@@ -21,6 +12,15 @@ export default class ImagesLoaded extends Component {
     this.imagesLoaded.on('done', done);
     this.imagesLoaded.on('fail', onFail);
     this.imagesLoaded.on('progress', onProgress);
+  };
+
+  initImagesLoaded = () => {
+    const { background } = this.props;
+    const { elemContainer } = this.refs;
+
+    /* Initializing imagesLoaded */
+    this.imagesLoaded = imagesLoaded(elemContainer, { background });
+    this.setEvents();
   };
 
   componentDidMount() {

--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,11 @@ export default class ImagesLoaded extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps !== this.props) {
-      // Do a re-initialization of imagesLoaded instance
-      // to fire events again. This may be useful if
-      // components that are using this, and needs to update
-      // images in result of e.g a state change.
+    if (prevProps.children !== this.props.children) {
+      // Do a re-initialization of the imagesLoaded instance.
+      // This may be useful if components that
+      // are using this needs to update
+      // images in children in result of a state change.
       this.initImagesLoaded();
     }
   }

--- a/stories/variants/FullPackage.js
+++ b/stories/variants/FullPackage.js
@@ -28,7 +28,7 @@ export default class FullPackage extends Component {
       this.setState({
         images: [
           ...this.state.images,
-          { src: 'http://via.placeholder.com/300x300' }
+          { src: 'http://via.placeholder.com/200x200' }
         ]
       });
     }, 3000);

--- a/stories/variants/FullPackage.js
+++ b/stories/variants/FullPackage.js
@@ -58,6 +58,10 @@ export default class FullPackage extends Component {
     });
   }
 
+  onUpdate = () => {
+    console.log('UPDATE - Children has updated and rerendered.');
+  };
+
   render() {
     const containerStyles = {
       display: 'flex',
@@ -74,6 +78,7 @@ export default class FullPackage extends Component {
           done={this.handleDone}
           onFail={this.handleOnFail}
           onProgress={this.handleOnProgress}
+          onUpdate={this.onUpdate}
           className={'My-new-class'}
           background={'.hey'}
         >

--- a/stories/variants/FullPackage.js
+++ b/stories/variants/FullPackage.js
@@ -23,6 +23,17 @@ export default class FullPackage extends Component {
     ]
   };
 
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        images: [
+          ...this.state.images,
+          { src: 'http://via.placeholder.com/300x300' }
+        ]
+      });
+    }, 3000);
+  }
+
   handleOnAlways = instance => {
     console.log('ALWAYS - all images have been loaded');
   };


### PR DESCRIPTION
This PR attempts to solving #14 , but it's just a implementation suggestion. Open for feedback on this one. 

The solution i came up with is this:

Every time children of  `<ImagesLoaded />` updates, the `imagesLoaded instance` re-initializes and fires all events again. This has been solved using `componentDidUpdate` for `props.children`-checks.

When `componentDidUpdate` fires, I've also added an `onUpdate`-prop that can be implemented like this:

```jsx
class ImagesLoadedTest extends React.Component {
  render() {
    return (
       <ImagesLoaded 
         onUpdate={() => console.log('children has updated')}
       >
        {/*....*/}
      </ImagesLoaded>
     )
  }
}
```